### PR TITLE
generic repo stuff, usability and compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,194 @@
+# Created by https://www.toptal.com/developers/gitignore/api/python,git
+# Edit at https://www.toptal.com/developers/gitignore?templates=python,git
+
+### Git ###
+# Created by git for backups. To disable backups in Git:
+# $ git config --global mergetool.keepBackup false
+*.orig
+
+# Created by git when using merge tools for conflicts
+*.BACKUP.*
+*.BASE.*
+*.LOCAL.*
+*.REMOTE.*
+*_BACKUP_*.txt
+*_BASE_*.txt
+*_LOCAL_*.txt
+*_REMOTE_*.txt
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
+# End of https://www.toptal.com/developers/gitignore/api/python,git
+
 .venv
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.venv
+.DS_Store

--- a/CreateKiCADProject.py
+++ b/CreateKiCADProject.py
@@ -84,11 +84,11 @@ class Application(tk.Frame):
 
             subprocess.run(["git", "init"], cwd=self.txt_project_name.get(), check=True)
             subprocess.run(["git", "add", "."], cwd=self.txt_project_name.get(), check=True)
-            subprocess.run(["git", "commit", "-m", '"Initial Commit"'], cwd=self.txt_project_name.get(), check=True)
+            subprocess.run(["git", "commit", "-m", '"chore: initial Commit"'], cwd=self.txt_project_name.get(), check=True)
             subprocess.run(["git", "remote", "add", "origin", self.txt_repo_url.get()], cwd=self.txt_project_name.get(), check=True)
-            subprocess.run(["git", "push", "-u", "origin", "master","--force"], cwd=self.txt_project_name.get(), check=True)
+            subprocess.run(["git", "push", "-u", "origin", "main","--force"], cwd=self.txt_project_name.get(), check=True)
             subprocess.run(["git", "submodule", "add", "https://github.com/ShirkyBooi/KiCADLibraries", "hardware/KiCAD Libraries"], cwd=self.txt_project_name.get(), check=True)
-            subprocess.run(["git", "commit", "-m", '"Added Library Submodule"'], cwd=self.txt_project_name.get(), check=True)
+            subprocess.run(["git", "commit", "-m", '"chore: added Library Submodule"'], cwd=self.txt_project_name.get(), check=True)
             subprocess.run(["git", "push"], cwd=self.txt_project_name.get(), check=True)
         except subprocess.CalledProcessError as e:
             messagebox.showerror("Error", str(e))

--- a/README.md
+++ b/README.md
@@ -5,3 +5,30 @@ This repository contains a script for use with my KiCAD Template and KiCAD Libra
 The script asks the user to enter some information for the cookiecutter template.
 
 It then initiates and commits the project to the repository URL provided and installs the library submodule.
+
+## Requirements
+
+### tkinter
+
+#### brew
+```sh
+brew install python-tk
+```
+
+#### apt
+```sh
+sudo apt-get install python3-tk 
+```
+
+#### Windows
+
+see [installation prompt](https://i.stack.imgur.com/yivqM.png)
+
+## Usage
+
+```sh
+python CreateKiCADProject.py
+```
+
+This should fetch the cookiecutter packages and open the GUI to run the template.
+


### PR DESCRIPTION
- adds a generic [.gitignore](https://github.com/wolffshots/CreateKiCADProject/blob/master/.gitignore) for python and git
- adds some content to the [README.md](https://github.com/wolffshots/CreateKiCADProject/blob/master/README.md) to explain pre-req and usage quickly
- switches the expected branch from `master` to `main` since that’s what the preferred global default is on GitHub and GitLab (see [this GitHub blogpost from 2020](https://github.blog/changelog/2020-08-26-set-the-default-branch-for-newly-created-repositories/) and [this GitLab blog post from 2021](https://about.gitlab.com/blog/2021/03/10/new-git-default-branch-name/)) - I’ve opened #1 to further address this
